### PR TITLE
Update xdrv_23_zigbee_5_2_converters.ino

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
@@ -463,6 +463,15 @@ uint32_t parseSingleAttribute(Z_attribute & attr, const SBuffer &buf,
         }
       }
       break;
+    case Zint24:      // int24
+      {
+        int32_t int24_val = ((buf.get8(i + 2) << 24) + (buf.get8(i + 1) << 16) +  (buf.get8(i) << 8)) >> 8;
+        // i += 3;
+        if (-0x800000 != int24_val) {
+          attr.setInt(int24_val);
+        }
+      }
+      break;
     case Zint32:      // int32
       {
         int32_t int32_val = buf.get32(i);


### PR DESCRIPTION
Add support for Zigbee payload field type 2A=int24

## Description:

Didn't write an issue, just fixed it. Not done changes to Tasmota earlier so not sure about the process.
Bought an OWON PC321-Z three phase Zigbee electricity meter, paired to a Sonoff ZbBridge with Tasmota 12.2.0 (zbbridge). Otherwise worked fine but Power fields "null". Checked incoming ZB data, found power fields do have OK data as 24 bit signed integer format (LSB) but Tasmota code lacking decoding of int24. Added this decoding, compiled and it worked, for positive and negative values, both <256 and >256 to be sure bytes are in the correct order.
Tested with ESP8266, I don't have an ESP32 ZigBee device to test with.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
